### PR TITLE
[MAINT] Updated pinned versions of dependencies in setup.cfg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ You can contribute in many ways:
 
 ### Report Bugs
 
-Report bugs at <https://github.com/richford/AFQ-Insight/issues>.
+Report bugs at <https://github.com/tractometry/AFQ-Insight/issues>.
 
 If you are reporting a bug, please include:
 
@@ -64,7 +64,7 @@ articles, and such.
 ### Submit Feedback
 
 The best way to send feedback is to file an issue at
-<https://github.com/richford/AFQ-Insight/issues>.
+<https://github.com/tractometry/AFQ-Insight/issues>.
 
 If you are proposing a feature:
 

--- a/afqinsight/_serial_bagging.py
+++ b/afqinsight/_serial_bagging.py
@@ -23,7 +23,8 @@ from sklearn.ensemble._bagging import (
     _parallel_predict_regression,
 )
 from sklearn.ensemble._base import _partition_estimators
-from sklearn.utils import check_array, check_random_state, indices_to_mask, resample
+from sklearn.utils import check_array, check_random_state, resample
+from sklearn.utils._mask import indices_to_mask
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.random import sample_without_replacement
 from sklearn.utils.validation import (

--- a/afqinsight/_serial_bagging.py
+++ b/afqinsight/_serial_bagging.py
@@ -611,7 +611,7 @@ class SerialBaggingClassifier(BaggingClassifier):
         else:
             return np.log(self.predict_proba(X))
 
-    @if_delegate_has_method(delegate="base_estimator")
+    @available_if(lambda est: hasattr(est.base_estimator, "decision_function"))
     def decision_function(self, X):
         """Average of the decision functions of the base classifiers.
 

--- a/afqinsight/_serial_bagging.py
+++ b/afqinsight/_serial_bagging.py
@@ -25,7 +25,7 @@ from sklearn.ensemble._bagging import (
 from sklearn.ensemble._base import _partition_estimators
 from sklearn.utils import check_array, check_random_state, resample
 from sklearn.utils._mask import indices_to_mask
-from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.random import sample_without_replacement
 from sklearn.utils.validation import (
     _check_sample_weight,

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >=3.10
 install_requires =
     scipy==1.13.1
     dipy>=1.0.0
-    matplotlib<3.9
+    matplotlib==3.9.3
     groupyr>=0.3.4
     numpy==1.23.5
     pandas==2.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pandas==2.1.4
     requests
     seaborn==0.13.0
-    scikit-learn>=1.5.0
+    scikit-learn==1.5.2
     sklearn_pandas>=2.0.0
     tqdm
     statsmodels==0.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     dipy==1.9.0
     matplotlib==3.9.3
     groupyr>=0.3.4
-    numpy==1.23.5
+    numpy==2.1.3
     pandas==2.2.3
     requests
     seaborn==0.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     matplotlib<3.9
     groupyr>=0.3.4
     numpy==1.23.5
-    pandas==2.1.4
+    pandas==2.2.3
     requests
     seaborn==0.13.2
     scikit-learn==1.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     dipy==1.9.0
     matplotlib==3.9.3
     groupyr>=0.3.4
-    numpy==2.1.3
+    numpy==1.26.4
     pandas==2.2.3
     requests
     seaborn==0.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     numpy==1.23.5
     pandas==2.1.4
     requests
-    seaborn==0.13.0
+    seaborn==0.13.2
     scikit-learn==1.5.2
     sklearn_pandas>=2.0.0
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pandas==2.1.4
     requests
     seaborn==0.13.0
-    scikit-learn==1.2.1
+    scikit-learn>=1.5.0
     sklearn_pandas>=2.0.0
     tqdm
     statsmodels==0.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
 python_requires = >=3.10
 install_requires =
     scipy==1.14.1
-    dipy>=1.0.0
+    dipy==1.9.0
     matplotlib==3.9.3
     groupyr>=0.3.4
     numpy==1.23.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     scikit-learn==1.5.2
     sklearn_pandas>=2.0.0
     tqdm
-    statsmodels==0.14.0
+    statsmodels==0.14.4
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
     setuptools_scm
 python_requires = >=3.10
 install_requires =
-    scipy==1.13.1
+    scipy==1.14.1
     dipy>=1.0.0
     matplotlib==3.9.3
     groupyr>=0.3.4


### PR DESCRIPTION
Limited manual test coverage in conda environment with python == 3.11. numpy2 breaks AFQ-Insight.
Closes #11. 

Changes:
- Updated pinned versions for scipy, dipy, matplotlib, numpy, pandas, seaborn, statsmodels, and scikit-learn.
- Changed imports for deprecated sklearn functions in serial_bagging.
- Change [contributing.md](http://contributing.md/) references for repo URL from richford to tractometry